### PR TITLE
 Add support for UsbManager.USB_DEVICE_ATTACHED action

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,18 @@
         </activity>
 
         <activity
+            android:name="com.sdrtouch.rtlsdr.UsbDelegate"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+        </activity>
+
+        <activity
             android:name="com.sdrtouch.rtlsdr.StreamActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
 
         <activity
             android:name="com.sdrtouch.rtlsdr.UsbDelegate"
+            android:theme = "@android:style/Theme.Translucent.NoTitleBar"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>

--- a/app/src/main/java/com/sdrtouch/rtlsdr/BinaryRunnerService.java
+++ b/app/src/main/java/com/sdrtouch/rtlsdr/BinaryRunnerService.java
@@ -52,12 +52,6 @@ public class BinaryRunnerService extends Service {
     public static final String ACTION_SDR_DEVICE_DETACHED = "com.sdrtouch.rtlsdr.SDR_DEVICE_DETACHED";
     public static final String EXTRA_DEVICE_NAME = "deviceName";
     public static final String EXTRA_SUPPORTED_TCP_CMDS = "supportedTcpCommands";
-    public static final String EXTRA_GAIN = "gain";
-    public static final String EXTRA_SAMPLERATE = "samplerate";
-    public static final String EXTRA_FREQUENCY = "frequency";
-    public static final String EXTRA_ADDRESS = "address";
-    public static final String EXTRA_PORT = "port";
-    public static final String EXTRA_PPM = "ppm";
 
 	private static final String TAG = "rtl_tcp_andro";
 	private final static int ONGOING_NOTIFICATION_ID = 438903919; // random id

--- a/app/src/main/java/com/sdrtouch/rtlsdr/BinaryRunnerService.java
+++ b/app/src/main/java/com/sdrtouch/rtlsdr/BinaryRunnerService.java
@@ -54,25 +54,25 @@ public class BinaryRunnerService extends Service {
 	private SdrDevice thisSdrDevice = null;
 	private final Set<StatusCallback> statusCallbacks = new HashSet<>();
 	private final Queue<Pair<SdrDevice, SdrTcpArguments>> workQueue = new LinkedList<>();
-		
+
 	@Override
 	public IBinder onBind(Intent arg0) {
 		return mBinder;
 	}
-	
+
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		startWithDevice();
 		return START_NOT_STICKY;
 	}
-	
+
 	private void addWork(SdrDevice sdrDevice, SdrTcpArguments arguments) {
 		synchronized (workQueue) {
 			Log.appendLine("Queueing");
 			workQueue.add(new Pair<>(sdrDevice, arguments));
 		}
 	}
-	
+
 	private void startWithDevice() {
 		Pair<SdrDevice, SdrTcpArguments> pair;
 		synchronized (workQueue) {
@@ -86,9 +86,10 @@ public class BinaryRunnerService extends Service {
 			if (isRunning) Log.appendLine("Restarting");
 			thisSdrDevice = pair.first;
 			SdrTcpArguments sdrTcpArguments = pair.second;
-			Log.appendLine("Arguments "+ sdrTcpArguments);
-			
-			Check.isNotNull(thisSdrDevice); Check.isNotNull(sdrTcpArguments);
+			Log.appendLine("Arguments " + sdrTcpArguments);
+
+			Check.isNotNull(thisSdrDevice);
+			Check.isNotNull(sdrTcpArguments);
 			announceRunning(thisSdrDevice);
 			thisSdrDevice.addOnStatusListener(onStatusListener);
 			thisSdrDevice.openAsync(this, sdrTcpArguments);
@@ -103,22 +104,22 @@ public class BinaryRunnerService extends Service {
 
 		startForeground(ONGOING_NOTIFICATION_ID, notification);
 	}
-	
+
 	private final OnStatusListener onStatusListener = new OnStatusListener() {
 		@Override
 		public void onOpen(SdrDevice sdrDevice) {
 			Log.appendLine("The rtl-tcp implementation is running and is ready to accept clients");
 			ackquireWakeLock();
 		}
-		
+
 		@Override
 		public void onClosed(Throwable e) {
 			if (e == null) {
 				Log.appendLine("Successfully closed service");
 			} else {
-				Log.appendLine("Closed service due to exception "+e.getClass().getSimpleName()+": "+e.getMessage());
+				Log.appendLine("Closed service due to exception " + e.getClass().getSimpleName() + ": " + e.getMessage());
 			}
-			
+
 			stopForeground(true);
 			thisSdrDevice = null;
 
@@ -129,10 +130,10 @@ public class BinaryRunnerService extends Service {
 				}
 			} catch (Throwable ignored) {}
 
-            startWithDevice();
+			startWithDevice();
 		}
 	};
-	
+
 	@SuppressWarnings("deprecation")
 	private void ackquireWakeLock() {
 		try {
@@ -146,18 +147,18 @@ public class BinaryRunnerService extends Service {
 			Log.appendLine("Acquired wake lock. Will keep the screen on.");
 		} catch (Throwable e) {e.printStackTrace();}
 	}
-	
+
 	public void closeService() {
 		if (isRunning) {
 			Log.appendLine("Closing device");
 			thisSdrDevice.close();
 		}
 	}
-	
+
 	public boolean isRunning() {
 		return isRunning;
 	}
-	
+
 	private void announceRunning(SdrDevice sdrDevice) {
 		Log.appendLine("Starting service with device %s", sdrDevice.getName());
 		isRunning = true;
@@ -165,7 +166,7 @@ public class BinaryRunnerService extends Service {
 			for (StatusCallback callback : statusCallbacks) callback.onServerRunning();
 		}
 	}
-	
+
 	private void announceNotRunning() {
 		Log.appendLine("Closing service");
 		isRunning = false;
@@ -173,19 +174,20 @@ public class BinaryRunnerService extends Service {
 			for (StatusCallback callback : statusCallbacks) callback.onServerNotRunning();
 		}
 	}
-		
+
 	public class LocalBinder extends Binder {
 		public BinaryRunnerService getService() {
-            return BinaryRunnerService.this;
-        }
-		
+			return BinaryRunnerService.this;
+		}
+
 		public void registerCallback(StatusCallback callback) {
 			synchronized (statusCallbacks) {
 				statusCallbacks.add(callback);
-				if (isRunning) callback.onServerRunning(); else callback.onServerNotRunning();
+				if (isRunning) callback.onServerRunning();
+				else callback.onServerNotRunning();
 			}
 		}
-		
+
 		public void startWithDevice(SdrDevice sdrDevice, SdrTcpArguments sdrTcpArguments) {
 			Check.isNotNull(sdrDevice);
 			Check.isNotNull(sdrTcpArguments);
@@ -193,8 +195,8 @@ public class BinaryRunnerService extends Service {
 			if (!isRunning) startService(new Intent(getApplicationContext(), BinaryRunnerService.class));
 			else closeService();
 		}
-    }
-	
+	}
+
 	public interface StatusCallback {
 		void onServerRunning();
 		void onServerNotRunning();

--- a/app/src/main/java/com/sdrtouch/rtlsdr/DeviceOpenActivity.java
+++ b/app/src/main/java/com/sdrtouch/rtlsdr/DeviceOpenActivity.java
@@ -51,18 +51,18 @@ import marto.rtl_tcp_andro.R;
 public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog.OnDeviceDialog {
 	
 	private final static SdrDeviceProvider[] SDR_DEVICE_PROVIDERS = new SdrDeviceProvider[] { new RtlSdrDeviceProvider() };
-    
+
 	private SdrTcpArguments sdrTcpArguments;
 	private SdrDevice sdrDevice;
 
-    private boolean isBound = false;
+	private boolean isBound = false;
 	private final ServiceConnection mConnection = new ServiceConnection() {
 
 		@Override
 		public void onServiceConnected(ComponentName name, IBinder ibinder) {
 			isBound = true;
 			LocalBinder binder = (LocalBinder) ibinder;
-            binder.startWithDevice(sdrDevice, sdrTcpArguments);
+			binder.startWithDevice(sdrDevice, sdrTcpArguments);
 		}
 
 		@Override
@@ -70,7 +70,7 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 			isBound = false;
 			finishWithError();
 		}
-    };
+	};
 	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -83,7 +83,7 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 		}
 		
 		setContentView(R.layout.progress);
-		
+
 		final Uri data = getIntent().getData();
 		try {
 			sdrTcpArguments = SdrTcpArguments.fromString(data.toString().replace("iqsrc://", ""));
@@ -153,7 +153,7 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 		try {
 			dialog.show(ft, "dialog");
 		} catch (Throwable t) {t.printStackTrace();}
-    }
+	}
 	
 	/** 
 	 * Starts the tcp binary
@@ -206,9 +206,9 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 		if (msg != null) data.putExtra("detailed_exception_message", msg);
 		
 		if (getParent() == null) {
-		    setResult(RESULT_CANCELED, data);
+			setResult(RESULT_CANCELED, data);
 		} else {
-		    getParent().setResult(RESULT_CANCELED, data);
+			getParent().setResult(RESULT_CANCELED, data);
 		}
 		finish();
 	}
@@ -233,9 +233,9 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 			finishWithError(err_info, id, null);
 			return;
 		}
-        Log.appendLine("Caught exception "+ExceptionTools.getNicelyFormattedTrace(e));
+		Log.appendLine("Caught exception "+ExceptionTools.getNicelyFormattedTrace(e));
 		e.printStackTrace();
-        finishWithError(err_info, id, e.getMessage());
+		finishWithError(err_info, id, e.getMessage());
 	}
 	
 	public void finishWithError(final err_info info, Integer second_id, String msg) {
@@ -258,9 +258,9 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 		data.putExtra("supportedTcpCommands", sdrDevice.getSupportedCommands());
 		
 		if (getParent() == null) {
-		    setResult(RESULT_OK, data);
+			setResult(RESULT_OK, data);
 		} else {
-		    getParent().setResult(RESULT_OK, data);
+			getParent().setResult(RESULT_OK, data);
 		}
 		
 		Log.appendLine("Device was open. Closing the prompt activity.");

--- a/app/src/main/java/com/sdrtouch/rtlsdr/DeviceOpenActivity.java
+++ b/app/src/main/java/com/sdrtouch/rtlsdr/DeviceOpenActivity.java
@@ -255,7 +255,9 @@ public class DeviceOpenActivity extends FragmentActivity implements DeviceDialog
 	
 	private void finishWithSuccess(SdrDevice sdrDevice) {
 		final Intent data = new Intent();
-		data.putExtra("supportedTcpCommands", sdrDevice.getSupportedCommands());
+		// SDR device
+		data.putExtra(BinaryRunnerService.EXTRA_SUPPORTED_TCP_CMDS, sdrDevice.getSupportedCommands());
+		data.putExtra(BinaryRunnerService.EXTRA_DEVICE_NAME, sdrDevice.getName());
 		
 		if (getParent() == null) {
 			setResult(RESULT_OK, data);

--- a/app/src/main/java/com/sdrtouch/rtlsdr/UsbDelegate.java
+++ b/app/src/main/java/com/sdrtouch/rtlsdr/UsbDelegate.java
@@ -42,8 +42,14 @@ public class UsbDelegate extends Activity {
             Log.appendLine(TAG + " USB attached: " + usbDevice.getDeviceName());
             Intent newIntent = new Intent(BinaryRunnerService.ACTION_SDR_DEVICE_ATTACHED);
             newIntent.putExtra(UsbManager.EXTRA_DEVICE, usbDevice);
-            startActivity(newIntent);
+            startActivityForResult(newIntent, 1234);
         }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.appendLine(TAG + " onActivityResult: requestCode=" + requestCode + " resultCode=" + resultCode);
+        if (requestCode != 1234) return; // This is the requestCode that was used with startActivityForResult
         finish();
     }
 }

--- a/app/src/main/java/com/sdrtouch/rtlsdr/UsbDelegate.java
+++ b/app/src/main/java/com/sdrtouch/rtlsdr/UsbDelegate.java
@@ -1,0 +1,137 @@
+/*
+ * rtl_tcp_andro is a library that uses libusb and librtlsdr to
+ * turn your Realtek RTL2832 based DVB dongle into a SDR receiver.
+ * It independently implements the rtl-tcp API protocol for native Android usage.
+ * Copyright (C) 2016 by Martin Marinov <martintzvetomirov@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sdrtouch.rtlsdr;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+import android.os.Bundle;
+import android.os.IBinder;
+
+import com.sdrtouch.core.SdrTcpArguments;
+import com.sdrtouch.core.devices.SdrDevice;
+import com.sdrtouch.rtlsdr.driver.RtlSdrDevice;
+import com.sdrtouch.tools.Log;
+
+public class UsbDelegate extends Activity {
+
+    private static final String TAG = UsbDelegate.class.getSimpleName();
+
+    private SdrTcpArguments sdrTcpArguments;
+    private SdrDevice sdrDevice;
+    private UsbDevice usbDevice;
+
+    private BinaryRunnerService service;
+    private final ServiceConnection mConnection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder ibinder) {
+            Log.appendLine(TAG + " onServiceConnected");
+            BinaryRunnerService.LocalBinder binder = (BinaryRunnerService.LocalBinder) ibinder;
+            service = binder.getService();
+            binder.startWithDevice(sdrDevice, sdrTcpArguments);
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            Log.appendLine(TAG + " onServiceDisconnected");
+            service = null;
+        }
+    };
+
+    private final SdrDevice.OnStatusListener onDeviceStatusListener = new  SdrDevice.OnStatusListener() {
+        @Override
+        public void onOpen(SdrDevice sdrDevice) {
+            Log.appendLine(TAG + " onOpen");
+
+            Intent intent = new Intent(BinaryRunnerService.ACTION_SDR_DEVICE_ATTACHED);
+            // USB device
+            intent.putExtra(UsbManager.EXTRA_DEVICE, usbDevice);
+            // SDR device
+            intent.putExtra(BinaryRunnerService.EXTRA_DEVICE_NAME, sdrDevice.getName());
+            intent.putExtra(BinaryRunnerService.EXTRA_SUPPORTED_TCP_CMDS, sdrDevice.getSupportedCommands());
+            //TODO add supported gain values
+            // TCP arguments
+            intent.putExtra(BinaryRunnerService.EXTRA_GAIN, sdrTcpArguments.getGain());
+            intent.putExtra(BinaryRunnerService.EXTRA_SAMPLERATE, sdrTcpArguments.getSamplerateHz());
+            intent.putExtra(BinaryRunnerService.EXTRA_FREQUENCY, sdrTcpArguments.getFrequencyHz());
+            intent.putExtra(BinaryRunnerService.EXTRA_ADDRESS, sdrTcpArguments.getAddress());
+            intent.putExtra(BinaryRunnerService.EXTRA_PORT, sdrTcpArguments.getPort());
+            intent.putExtra(BinaryRunnerService.EXTRA_PPM, sdrTcpArguments.getPpm());
+
+            startActivityForResult(intent, 1234);
+        }
+
+        @Override
+        public void onClosed(Throwable e) {
+            Log.appendLine(TAG + " onClosed");
+            finish();
+        }
+    };
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.appendLine(TAG + " onActivityResult: requestCode=" + requestCode + " resultCode=" + resultCode);
+        if (requestCode != 1234) return; // This is the requestCode that was used with startActivityForResult
+        if (resultCode != RESULT_OK) {
+            //stop the service
+            if (service != null && service.isRunning()) {
+                service.closeService();
+            }
+        }
+        finish();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+
+        if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(intent.getAction())) {
+            Log.appendLine(TAG + " USB attached");
+            usbDevice = (UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+            sdrTcpArguments = SdrTcpArguments.fromString("-a 127.0.0.1 -p 1234 -s 2048000");
+            sdrDevice = new RtlSdrDevice(usbDevice);
+            sdrDevice.addOnStatusListener(onDeviceStatusListener);
+
+            //start the service
+            Intent serviceIntent = new Intent(this, BinaryRunnerService.class);
+            bindService(serviceIntent, mConnection, Context.BIND_AUTO_CREATE);
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        Log.appendLine(TAG + " onStop");
+        if (service != null) unbindService(mConnection);
+
+        usbDevice = null;
+        sdrDevice = null;
+        sdrTcpArguments = null;
+    }
+}

--- a/app/src/main/java/com/sdrtouch/tools/Log.java
+++ b/app/src/main/java/com/sdrtouch/tools/Log.java
@@ -36,7 +36,7 @@ public abstract class Log {
 
 	@UsedByJni
 	public static void appendLine(String what) {
-		android.util.Log.d("Log", what);
+		android.util.Log.d("RtlSdr", what);
 		while (what.charAt(what.length()-1) == '\n') {
 			what = what.substring(0, what.length()-1);
 		}


### PR DESCRIPTION
Add support for UsbManager.USB_DEVICE_ATTACHED action as described in https://developer.android.com/guide/topics/connectivity/usb/host.html chapter "Working with Devices".
This enabled the driver to receive the UsbManager.ACTION_USB_DEVICE_ATTACHED intent, which will be forwarded as ACTION_SDR_DEVICE_ATTACHED intent. The receiving application uses the already existing mechanism as described within the README.md to start the RTL-SDR driver. But to ensure that the RTL-SDR driver initialises the newly attached USB device, the application needs to add the received USB device from the ACTION_SDR_DEVICE_ATTACHED action to the new intent as follows:

```
    public static final String ACTION_SDR_DEVICE_ATTACHED = "com.sdrtouch.rtlsdr.SDR_DEVICE_ATTACHED";
    ...
    @Override
    public void onCreate(Bundle savedInstanceState)
    {
        super.onCreate(savedInstanceState);
        Intent intent = getIntent();

        if (intent.getAction().equals(ACTION_SDR_DEVICE_ATTACHED)) {
            UsbDevice usbDevice = (UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
            Log.i(TAG, "USB attached: " + usbDevice.getDeviceName());

            Intent newIntent = new Intent(Intent.ACTION_VIEW).setData(Uri.parse("iqsrc://-a 127.0.0.1 -p "+ port + " -s "+ samplerate));
            newIntent.putExtra(UsbManager.EXTRA_DEVICE, usbDevice);
            startActivityForResult(newIntent, 1234);
        }
    }
```
The following intent filter need to be added to receive the ACTION_SDR_DEVICE_ATTACHED intent:

```
    <intent-filter>
        <category android:name="android.intent.category.DEFAULT"/>
        <action android:name="com.sdrtouch.rtlsdr.SDR_DEVICE_ATTACHED"/>
    </intent-filter>
```