### PR TITLE
Compatibility App added for Free Android App : "ADSB Flight Tracker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you want to control the tuner, such as set the central frequency, you can sen
 * [Wavesink DAB/FM](https://play.google.com/store/apps/details?id=de.ses.wavesink)
 * [RF Analyzer](https://play.google.com/store/apps/details?id=com.mantz_it.rfanalyzer)
 * [welle.io](https://play.google.com/store/apps/details?id=io.welle.welle)
+* [ADSB Flight Tracker] (https://play.google.com/store/apps/details?id=com.enthusiasticcoder.adsbflightmonitor)
 
 Open a github issue if you want your app to be featured here!
 


### PR DESCRIPTION
My free App now uses the RTL-TCP driver to stream ADSB flight data to a radar like screen in both 2D and 3D.

See link for free download.

https://play.google.com/store/apps/details?id=com.enthusiasticcoder.adsbflightmonitor&hl=en_GB